### PR TITLE
Enable logging via puppet

### DIFF
--- a/stingray/manifests/virtual_server.pp
+++ b/stingray/manifests/virtual_server.pp
@@ -87,13 +87,15 @@
 # Copyright 2013 Riverbed Technology
 #
 define stingray::virtual_server(
-    $address = '*',
-    $port = 80,
-    $protocol = 'http',
-    $pool = 'discard',
-    $enabled = 'no',
-    $ssl_decrypt = 'no',
-    $ssl_certificate = undef
+    $address            = '*',
+    $port               = 80,
+    $protocol           = 'http',
+    $pool               = 'discard',
+    $enabled            = 'no',
+    $ssl_decrypt        = 'no',
+    $ssl_certificate    = undef,
+    $enable_logging     = false,
+    $log_filename       = '%zeushome%/zxtm/log/%v.log'
 
 ) {
     include stingray

--- a/stingray/templates/virtual_server.erb
+++ b/stingray/templates/virtual_server.erb
@@ -7,12 +7,16 @@ private_key <%= @ssl_certificate%>.private
 public_cert <%= @ssl_certificate%>.public
 <% end -%>
 protocol <%= @proto_code %>
+<% if @enable_logging -%>
+log!enabled     Yes
+log!filename    <%= @log_filename %>
+<% end -%>
 <% if @ssl_decrypt == "yes" then -%>ssl_decrypt Yes
 ssl_ocsp!issuer!_DEFAULT_!aia	Yes
 ssl_ocsp!issuer!_DEFAULT_!nonce	off
 ssl_ocsp!issuer!_DEFAULT_!required	optional
-ssl_ocsp!issuer!_DEFAULT_!responder_cert	
-ssl_ocsp!issuer!_DEFAULT_!signer	
+ssl_ocsp!issuer!_DEFAULT_!responder_cert
+ssl_ocsp!issuer!_DEFAULT_!signer
 ssl_ocsp!issuer!_DEFAULT_!url<% end %>
 pool <%= @pool.class == Array ? @pool * " " : @pool%>
 <% if @response_rules then-%>


### PR DESCRIPTION
Enable logging via the puppet module by adding an extra parameter called enable_logging, the ability to set a custom location for logs is also available if enable_logging is set to true.
