### PR TITLE
Added check for existing wget package declaration.

### DIFF
--- a/stingray/manifests/init.pp
+++ b/stingray/manifests/init.pp
@@ -46,8 +46,10 @@ class stingray (
 
 ) inherits stingray::params {
 
-    package {
-        'wget':;
+    if !defined(Package['wget']) {
+		    package {
+		        'wget':;
+		    }  
     }
 
     Exec { path => '/usr/bin:/bin:/usr/sbin:/sbin' }


### PR DESCRIPTION
Hi Faisal,

We would like to use the riverbed/stingray module but it declares the wget package which we are already declaring elsewhere, resulting in catalog compile errors.

This pull request simply wraps the wget package declaration in an "if !defined" block, which neatly avoids the problem. Please consider adding it to your codebase.

Thanks,

Simon.
