### PR TITLE
Typo in rule.pp

### DIFF
--- a/stingray/manifests/rule.pp
+++ b/stingray/manifests/rule.pp
@@ -35,7 +35,7 @@ define stingray::rule(
     info ("Import rule ${name}")
     file { "${path}/zxtm/conf/rules/${name}":
         ensure => 'present',
-        source => $file
+        source => $file,
         notify => Exec['replicate_config']
     }
 }


### PR DESCRIPTION
There is a syntax error in rule.pp and this PR fixes the issue
