### PR TITLE
Add support for STM version 9.6

### DIFF
--- a/stingray/manifests/init.pp
+++ b/stingray/manifests/init.pp
@@ -72,7 +72,7 @@ class stingray (
               '9.3r1': {$image_loc = 'https://support.riverbed.com/download.htm?sid=9esd1sqo1eqr4vsde24jr3eeut'}
               '9.4':   {$image_loc = 'https://support.riverbed.com/download.htm?sid=seinh554d2ku21084es3l0ssgr'}
               '9.5':   {$image_loc = 'https://support.riverbed.com/download.htm?sid=apehpa9084mt0q3o00q13ef07o'}
-              default: { fail("Version ${version} is not supported.  Supported versions are 9.1 till 9.4") }
+              default: { fail("Version ${version} is not supported.  Supported versions are 9.1 till 9.5") }
           }
       } else {
           case $version {
@@ -83,7 +83,8 @@ class stingray (
               '9.3r1': {$image_loc = 'https://support.riverbed.com/download.htm?sid=t01dd49gtrl85lqus3q7md6qkl'}
               '9.4':   {$image_loc = 'https://support.riverbed.com/download.htm?sid=biuhlvmnlt3jna7kq8ab2u69jk'}
               '9.5':   {$image_loc = 'https://support.riverbed.com/download.htm?sid=faudva1r9hrbcie5a6b509aoti'}
-              default: { fail("Version ${version} is not supported.  Supported versions are 9.1 till 9.4") }
+              '9.6':   {$image_loc = 'https://support.riverbed.com/download.htm?sid=vdg19dt684868npc3fggd750pn'}
+              default: { fail("Version ${version} is not supported.  Supported versions are 9.1 till 9.6") }
           }
       }
     }


### PR DESCRIPTION
Added support for the newly released version of STM 9.6. This appears to have only been released in 64-bit, so this hasn't been added to the "x86" part of the case statement.

I've also updated the "fail" error messages as these showed old version numbers.
